### PR TITLE
Error if the key range exist before generating the keys

### DIFF
--- a/libgoal/participation.go
+++ b/libgoal/participation.go
@@ -154,6 +154,12 @@ func (c *Client) GenParticipationKeysTo(address string, firstValid, lastValid, k
 	if err != nil {
 		return
 	}
+	_, err = os.Stat(partKeyPath)
+	if !os.IsNotExist(err) {
+		err = fmt.Errorf("ParticipationKeys exist for the range %d to %d", firstRound, lastRound)
+		return
+	}
+
 	partdb, err := db.MakeErasableAccessor(partKeyPath)
 	if err != nil {
 		return


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary
When the exact range of keys exist, there will be a wallet database file in the node's folder. 
However, the keys will be generated anyway, taking possibly a long time, before an error be reported that the database table already exists. 

To enhance the user experience, anticipate the error by first checking if the database file exists, and report an error if so. Otherwise, generate the keys and insert into the database.

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
