### PR TITLE
Add signature compatibility version checks to votes and compact certs

### DIFF
--- a/agreement/vote.go
+++ b/agreement/vote.go
@@ -126,7 +126,7 @@ func (uv unauthenticatedVote) verify(l LedgerReader) (vote, error) {
 
 	ephID := basics.OneTimeIDForRound(rv.Round, m.Record.KeyDilution(proto))
 	voteID := m.Record.VoteID
-	if !voteID.Verify(ephID, rv, uv.Sig) {
+	if !voteID.Verify(ephID, rv, uv.Sig, proto.EnableBatchVerification) {
 		return vote{}, fmt.Errorf("unauthenticatedVote.verify: could not verify FS signature on vote by %v given %v: %+v", rv.Sender, voteID, uv)
 	}
 

--- a/crypto/compactcert/builder.go
+++ b/crypto/compactcert/builder.go
@@ -99,7 +99,7 @@ func (b *Builder) Add(pos uint64, sig crypto.OneTimeSignature, verifySig bool) e
 
 	// Check signature
 	ephID := basics.OneTimeIDForRound(b.SigRound, p.KeyDilution)
-	if verifySig && !p.PK.Verify(ephID, b.Msg, sig) {
+	if verifySig && !p.PK.Verify(ephID, b.Msg, sig, b.EnableBatchVerification) {
 		return fmt.Errorf("signature does not verify under ID %v", ephID)
 	}
 

--- a/crypto/compactcert/structs.go
+++ b/crypto/compactcert/structs.go
@@ -28,6 +28,8 @@ type Params struct {
 	ProvenWeight uint64          // Weight threshold proven by the certificate
 	SigRound     basics.Round    // Ephemeral signature round to expect
 	SecKQ        uint64          // Security parameter (k+q) from analysis document
+
+	EnableBatchVerification bool // whether ED25519 batch verification is enabled
 }
 
 // CompactOneTimeSignature is crypto.OneTimeSignature with omitempty

--- a/crypto/compactcert/verifier.go
+++ b/crypto/compactcert/verifier.go
@@ -56,7 +56,7 @@ func (v *Verifier) Verify(c *Cert) error {
 		parts[pos] = crypto.HashObj(r.Part)
 
 		ephID := basics.OneTimeIDForRound(v.SigRound, r.Part.KeyDilution)
-		if !r.Part.PK.Verify(ephID, v.Msg, r.SigSlot.Sig.OneTimeSignature) {
+		if !r.Part.PK.Verify(ephID, v.Msg, r.SigSlot.Sig.OneTimeSignature, v.EnableBatchVerification) {
 			return fmt.Errorf("signature in reveal pos %d does not verify", pos)
 		}
 	}

--- a/crypto/curve25519_test.go
+++ b/crypto/curve25519_test.go
@@ -33,7 +33,7 @@ func TestSignVerifyEmptyMessage(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	pk, sk := ed25519GenerateKey()
 	sig := ed25519Sign(sk, []byte{})
-	if !ed25519Verify(pk, []byte{}, sig) {
+	if !ed25519Verify(pk, []byte{}, sig, true) {
 		t.Errorf("sig of an empty message failed to verify")
 	}
 }

--- a/crypto/onetimesig.go
+++ b/crypto/onetimesig.go
@@ -310,7 +310,7 @@ func (s *OneTimeSignatureSecrets) Sign(id OneTimeSignatureIdentifier, message Ha
 // OneTimeSignatureVerifier and some OneTimeSignatureIdentifier.
 //
 // It returns true if this is the case; otherwise, it returns false.
-func (v OneTimeSignatureVerifier) Verify(id OneTimeSignatureIdentifier, message Hashable, sig OneTimeSignature) bool {
+func (v OneTimeSignatureVerifier) Verify(id OneTimeSignatureIdentifier, message Hashable, sig OneTimeSignature, batchVersionCompatible bool) bool {
 	offsetID := OneTimeSignatureSubkeyOffsetID{
 		SubKeyPK: sig.PK,
 		Batch:    id.Batch,
@@ -321,13 +321,13 @@ func (v OneTimeSignatureVerifier) Verify(id OneTimeSignatureIdentifier, message 
 		Batch:    id.Batch,
 	}
 
-	if !ed25519Verify(ed25519PublicKey(v), hashRep(batchID), sig.PK2Sig) {
+	if !ed25519Verify(ed25519PublicKey(v), hashRep(batchID), sig.PK2Sig, batchVersionCompatible) {
 		return false
 	}
-	if !ed25519Verify(batchID.SubKeyPK, hashRep(offsetID), sig.PK1Sig) {
+	if !ed25519Verify(batchID.SubKeyPK, hashRep(offsetID), sig.PK1Sig, batchVersionCompatible) {
 		return false
 	}
-	if !ed25519Verify(offsetID.SubKeyPK, hashRep(message), sig.Sig) {
+	if !ed25519Verify(offsetID.SubKeyPK, hashRep(message), sig.Sig, batchVersionCompatible) {
 		return false
 	}
 	return true

--- a/crypto/onetimesig_test.go
+++ b/crypto/onetimesig_test.go
@@ -44,44 +44,44 @@ func testOneTimeSignVerifyNewStyle(t *testing.T, c *OneTimeSignatureSecrets, c2 
 	s2 := randString()
 
 	sig := c.Sign(id, s)
-	if !c.Verify(id, s, sig) {
+	if !c.Verify(id, s, sig, true) {
 		t.Errorf("correct signature failed to verify (ephemeral)")
 	}
 
-	if c.Verify(id, s2, sig) {
+	if c.Verify(id, s2, sig, true) {
 		t.Errorf("signature verifies on wrong message")
 	}
 
 	sig2 := c2.Sign(id, s)
-	if c.Verify(id, s, sig2) {
+	if c.Verify(id, s, sig2, true) {
 		t.Errorf("wrong master key incorrectly verified (ephemeral)")
 	}
 
 	otherID := randID()
-	if c.Verify(otherID, s, sig) {
+	if c.Verify(otherID, s, sig, true) {
 		t.Errorf("signature verifies for wrong ID")
 	}
 
 	nextOffsetID := id
 	nextOffsetID.Offset++
-	if c.Verify(nextOffsetID, s, sig) {
+	if c.Verify(nextOffsetID, s, sig, true) {
 		t.Errorf("signature verifies after changing offset")
 	}
 
 	c.DeleteBeforeFineGrained(nextOffsetID, 256)
 	sigAfterDelete := c.Sign(id, s)
-	if c.Verify(id, s, sigAfterDelete) { // TODO(adam): Previously, this call to Verify was verifying old-style coarse-grained one-time signatures. Now it's verifying new-style fine-grained one-time signatures. Is this correct?
+	if c.Verify(id, s, sigAfterDelete, true) { // TODO(adam): Previously, this call to Verify was verifying old-style coarse-grained one-time signatures. Now it's verifying new-style fine-grained one-time signatures. Is this correct?
 		t.Errorf("signature verifies after delete offset")
 	}
 
 	sigNextAfterDelete := c.Sign(nextOffsetID, s)
-	if !c.Verify(nextOffsetID, s, sigNextAfterDelete) {
+	if !c.Verify(nextOffsetID, s, sigNextAfterDelete, true) {
 		t.Errorf("signature fails to verify after deleting up to this offset")
 	}
 
 	nextOffsetID.Offset++
 	sigNext2AfterDelete := c.Sign(nextOffsetID, s)
-	if !c.Verify(nextOffsetID, s, sigNext2AfterDelete) {
+	if !c.Verify(nextOffsetID, s, sigNext2AfterDelete, true) {
 		t.Errorf("signature fails to verify after deleting up to previous offset")
 	}
 
@@ -92,18 +92,18 @@ func testOneTimeSignVerifyNewStyle(t *testing.T, c *OneTimeSignatureSecrets, c2 
 	nextBatchOffsetID.Offset++
 	c.DeleteBeforeFineGrained(nextBatchOffsetID, 256)
 	sigAfterDelete = c.Sign(nextBatchID, s)
-	if c.Verify(nextBatchID, s, sigAfterDelete) {
+	if c.Verify(nextBatchID, s, sigAfterDelete, true) {
 		t.Errorf("signature verifies after delete")
 	}
 
 	sigNextAfterDelete = c.Sign(nextBatchOffsetID, s)
-	if !c.Verify(nextBatchOffsetID, s, sigNextAfterDelete) {
+	if !c.Verify(nextBatchOffsetID, s, sigNextAfterDelete, true) {
 		t.Errorf("signature fails to verify after delete up to this offset")
 	}
 
 	nextBatchOffsetID.Offset++
 	sigNext2AfterDelete = c.Sign(nextBatchOffsetID, s)
-	if !c.Verify(nextBatchOffsetID, s, sigNext2AfterDelete) {
+	if !c.Verify(nextBatchOffsetID, s, sigNext2AfterDelete, true) {
 		t.Errorf("signature fails to verify after delete up to previous offset")
 	}
 
@@ -114,27 +114,27 @@ func testOneTimeSignVerifyNewStyle(t *testing.T, c *OneTimeSignatureSecrets, c2 
 
 	preBigJumpID := bigJumpID
 	preBigJumpID.Batch--
-	if c.Verify(preBigJumpID, s, c.Sign(preBigJumpID, s)) {
+	if c.Verify(preBigJumpID, s, c.Sign(preBigJumpID, s), true) {
 		t.Errorf("preBigJumpID verifies")
 	}
 
 	preBigJumpID.Batch++
 	preBigJumpID.Offset--
-	if c.Verify(preBigJumpID, s, c.Sign(preBigJumpID, s)) {
+	if c.Verify(preBigJumpID, s, c.Sign(preBigJumpID, s), true) {
 		t.Errorf("preBigJumpID verifies")
 	}
 
-	if !c.Verify(bigJumpID, s, c.Sign(bigJumpID, s)) {
+	if !c.Verify(bigJumpID, s, c.Sign(bigJumpID, s), true) {
 		t.Errorf("bigJumpID does not verify")
 	}
 
 	bigJumpID.Offset++
-	if !c.Verify(bigJumpID, s, c.Sign(bigJumpID, s)) {
+	if !c.Verify(bigJumpID, s, c.Sign(bigJumpID, s), true) {
 		t.Errorf("bigJumpID.Offset++ does not verify")
 	}
 
 	bigJumpID.Batch++
-	if !c.Verify(bigJumpID, s, c.Sign(bigJumpID, s)) {
+	if !c.Verify(bigJumpID, s, c.Sign(bigJumpID, s), true) {
 		t.Errorf("bigJumpID.Batch++ does not verify")
 	}
 }

--- a/ledger/internal/compactcert.go
+++ b/ledger/internal/compactcert.go
@@ -136,6 +136,8 @@ func CompactCertParams(votersHdr bookkeeping.BlockHeader, hdr bookkeeping.BlockH
 		ProvenWeight: provenWeight,
 		SigRound:     hdr.Round + 1,
 		SecKQ:        proto.CompactCertSecKQ,
+
+		EnableBatchVerification: proto.EnableBatchVerification,
 	}
 	return
 }

--- a/node/netprio.go
+++ b/node/netprio.go
@@ -131,7 +131,7 @@ func (node *AlgorandFullNode) VerifyPrioResponse(challenge string, response []by
 	}
 
 	ephID := basics.OneTimeIDForRound(rs.Round, data.KeyDilution(proto))
-	if !data.VoteID.Verify(ephID, rs.Response, rs.Sig) {
+	if !data.VoteID.Verify(ephID, rs.Response, rs.Sig, proto.EnableBatchVerification) {
 		err = fmt.Errorf("signature verification failure")
 		return
 	}


### PR DESCRIPTION
This pushes the batch verification compatibility flag added in https://github.com/algorand/go-algorand/pull/3031 down all the way to the lowest level in `github.com/algorand/go-algorand/crypto.ed25519Verify()`, which catches a few more uses of it in the code base. Signatures used in votes and compact certs were not yet handled, so I wired them up to check the consensus parameter EnableBatchVerification as well.